### PR TITLE
Some small changes to MR.CLAM parsing -- mostly to address discretization bud

### DIFF
--- a/py_factor_graph/io/mrclam_data.py
+++ b/py_factor_graph/io/mrclam_data.py
@@ -127,11 +127,11 @@ def add_landmarks(
 def get_all_measurements(
     barcode_fname: str,
     data_dir: str,
-    descretize_period: 0.05,
+    discretize_period: float = 0.05,
 ):
     """
     Returns a dataframe with all range-bearing measurements from all robots in ascending timestamp
-    Descretizes timestamps to align them
+    discretizes timestamps to align them
 
     Filters out measurements with unknown barcodes
     """
@@ -185,10 +185,10 @@ def get_all_measurements(
 
         all_measurement_df = pd.concat([all_measurement_df, measurement_df])
 
-    # Round timestamp to 20Hz precision
-    all_measurement_df["timestamp"] = all_measurement_df["timestamp"].apply(
-        lambda x: round(x * descretize_period) / descretize_period
-    )
+    # round timestamp to nearest multiple of discretize_period
+    all_measurement_df["timestamp"] = (
+        all_measurement_df["timestamp"] // discretize_period
+    ) * discretize_period
 
     # Sort by timestamp
     all_measurement_df.sort_values(by="timestamp", inplace=True)
@@ -391,7 +391,9 @@ def parse_data(
             else measured_var_name,
         )
         if association in existing_ranges or association[::-1] in existing_ranges:
-            logging.info("Skipping duplicate measurement")
+            logging.info(
+                f"Skipping duplicate measurement between {association} and {association[::-1]}"
+            )
             continue
         existing_ranges.add(association)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ install_requires=
     evo
     PyQt5
     coloredlogs
+    tqdm
 
 packages = find:
 


### PR DESCRIPTION
**Summary**
- modified the discretization code to properly round down to the nearest multiple of discretization period 
- fixed typo descretize -> discretize
- some small tweaks to make `mypy` happy with the typing

**Reason for fixes**
I did this because it seemed like when running on MRCLAM1 data set way too many measurements were being thrown out. The PyFG summary I got from that data set:

`
Robots: 5 || Variables: 375 poses, 15 landmarks || Measurements: 370 odom, 1596 pose to landmark, 386 range, 0 loop closures Interrobot loop closures: No inter-robot loop closures
`

**Key points**
The functional fixes are all in  e3f631d28834dbaf51bc693649dda27d437f2ae4, with the most important diff at `py_factor_graph/io/mrclam_data.py:188`.

**NOTE**: I chose to round **down** as opposed to exactly the nearest multiple. I don't feel strongly about the rounding scheme but wanted to point this out.

Please look over and test - I tried to verify everything looked correct with print statements but is always potential for error